### PR TITLE
Wait for form visibility before scrolling

### DIFF
--- a/Samokat-TP.py
+++ b/Samokat-TP.py
@@ -601,11 +601,19 @@ async def run_browser():
 
             await emulate_user_reading(page, total_time, LOG_FILE)
 
+            wait_start = asyncio.get_event_loop().time()
+            while True:
+                if await is_form_visible(page):
+                    break
+                if asyncio.get_event_loop().time() - wait_start > 9:
+                    error_msg = "Форма не появилась на экране"
+                    log(f"[ERROR] {error_msg}", LOG_FILE)
+                    raise Exception(error_msg)
+                await asyncio.sleep(0.3)
 
-
-            # ====================================================================================
+            # ==================================================================
             # Быстрые крупные скроллы к форме, без телепортов
-            # ====================================================================================
+            # ==================================================================
             await smooth_scroll_to_form(page)
 
             # ====================================================================================


### PR DESCRIPTION
## Summary
- wait up to 9s for `.form-wrapper` to be visible
- log and abort if the form never appears
- keep smooth scroll behavior once the form is visible

## Testing
- `python3 -m py_compile Samokat-TP.py`


------
https://chatgpt.com/codex/tasks/task_e_68779fb58a3883218eb2bcf9b24f832a