### PR TITLE
Config clean-ups

### DIFF
--- a/Samokat-TP.py
+++ b/Samokat-TP.py
@@ -21,7 +21,6 @@ import json
 import os
 from datetime import datetime
 from python_ghost_cursor.playwright_async import create_cursor
-from pathlib import Path
 from samokat_config import load_cfg
 
 def make_log_file(phone):
@@ -37,6 +36,7 @@ def log(msg, LOG_FILE):
         f.write(f"{ts}  {msg}\n")
 
 try:
+    from pathlib import Path
     params = json.load(sys.stdin)
     user_phone = params.get("user_phone", "")
     LOG_FILE = make_log_file(user_phone)
@@ -67,22 +67,6 @@ PAGE_GOTO_TIMEOUT = CFG["PAGE_GOTO_TIMEOUT"]
 FORM_WRAPPER_TIMEOUT = CFG["FORM_WRAPPER_TIMEOUT"]
 REDIRECT_TIMEOUT = CFG["REDIRECT_TIMEOUT"]
 MODAL_SELECTOR_TIMEOUT = CFG["MODAL_SELECTOR_TIMEOUT"]
-
-cfg_dict = {
-    "UA": EXTRA_UA,
-    "HEADLESS": headless_flag,
-    "BLOCK_PATTERNS": BLOCK_PATTERNS,
-    "HUMAN_DELAY_μ": HUMAN_DELAY_MU,
-    "HUMAN_DELAY_σ": HUMAN_DELAY_SIGMA,
-    "TYPO_PROB": TYPO_PROB,
-    "SCROLL_STEP": SCROLL_STEP,
-    "WEBHOOK_TIMEOUT": WEBHOOK_TIMEOUT,
-    "SELECT_ITEM_TIMEOUT": SELECT_ITEM_TIMEOUT,
-    "PAGE_GOTO_TIMEOUT": PAGE_GOTO_TIMEOUT,
-    "FORM_WRAPPER_TIMEOUT": FORM_WRAPPER_TIMEOUT,
-    "REDIRECT_TIMEOUT": REDIRECT_TIMEOUT,
-    "MODAL_SELECTOR_TIMEOUT": MODAL_SELECTOR_TIMEOUT,
-}
 
 # Дополнительные параметры из полученного JSON
 phone_from_Avito = params.get("phone_from_Avito", "")

--- a/samokat_config.py
+++ b/samokat_config.py
@@ -67,13 +67,13 @@ def _convert(val: Any, typ: type) -> Any:
         return float(val)
     if typ is list:
         if isinstance(val, str):
-            return json.loads(val)
+            return [] if val == "" else json.loads(val)
         if isinstance(val, list):
             return val
         raise ValueError
     if typ is dict:
         if isinstance(val, str):
-            return json.loads(val)
+            return {} if val == "" else json.loads(val)
         if isinstance(val, dict):
             return val
         raise ValueError
@@ -134,8 +134,18 @@ def load_cfg(base_dir: Path, env_file: Path | None = None, cli_overrides: Mappin
 
     for key in list(result.keys()):
         if key not in final:
-            log(f"[WARN] Unknown cfg key {key}", LOG_FILE)
+            log(f"[WARN] Unknown cfg key {key} ignored", LOG_FILE)
 
     overrides = {k: final[k] for k in final if defaults.get(k) != final[k]}
     log(f"[INFO] CONFIG loaded ok, overrides: {overrides}", LOG_FILE)
     return final
+
+
+if __name__ == "__main__":
+    print(
+        json.dumps(
+            load_cfg(Path(__file__).parent),
+            indent=2,
+            ensure_ascii=False,
+        )
+    )


### PR DESCRIPTION
## Summary
- remove unused `cfg_dict` block
- import `Path` only inside the parameter-parsing block
- allow empty strings for list/dict values in `samokat_config._convert`
- tweak ignored-key warning wording
- add quick dump helper in `samokat_config.py`

## Testing
- `python samokat_config.py`
- `python samokat_config.py` with `.env` containing `BLOCK_PATTERNS=""` and `SCROLL_STEP=""`

------
https://chatgpt.com/codex/tasks/task_e_687fd5864b908321ad35ba40b2f43616