### PR TITLE
Add hot config reload with watchdog

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 python-dotenv>=1.0
+watchdog>=3.0


### PR DESCRIPTION
## Summary
- implement `reload_cfg` and store global configuration in `samokat_config`
- add watchdog based async watcher and flag `--no-watch`
- access configuration directly from global `CFG`
- update requirements with `watchdog`

## Testing
- `python -m py_compile Samokat-TP.py samokat_config.py`

------
https://chatgpt.com/codex/tasks/task_e_687fdaa36c6483218a6af250f3176e91