### PR TITLE
Fix requirements to use ghost-cursor

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,7 @@ python-dotenv>=1.0
 playwright>=1.44
 # stealth plug-in (keep old pinned commit → оно стабильнее)
 playwright-stealth==2.0.0
+# cursor movement automation
+ghost-cursor==0.0.7 # pip package; import = python_ghost_cursor
 # only for local checks (optional): leave or drop
 pytest>=7.0


### PR DESCRIPTION
## Summary
- depend on ghost-cursor instead of python-ghost-cursor

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement ghost-cursor==0.0.7)*

------
https://chatgpt.com/codex/tasks/task_e_68810f816d148321a65cda6f18d139b8