### PR TITLE
feat: allow headless override via JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,23 @@ Run script
 cat params.json | python Samokat-TP.py
 ```
 
+Пример JSON с принудительным `headless`:
+
+```bash
+cat <<EOF | python Samokat-TP.py
+{
+  "user_phone": "79991234567",
+  "user_name":  "Вася",
+  "headless":   true
+}
+EOF
+```
+
 С прокси
 
 ```bash
 cat params.json | python Samokat-TP.py --proxy=http://1.2.3.4:8080
 ```
 
-params.json – тот же JSON, который n8n отправляет в stdin.
+params.json – тот же JSON, который n8n отправляет в stdin. При отсутствии поля
+`headless` используется значение по умолчанию из `config_defaults.json`.


### PR DESCRIPTION
## Summary
- allow overriding Playwright `headless` mode via JSON
- document how to send the `headless` flag

## Testing
- `python -m py_compile Samokat-TP.py`


------
https://chatgpt.com/codex/tasks/task_e_68813fb3e35c8321a18961a4caf805fe