### PR TITLE
Pin playwright-stealth to 2.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ python-dotenv>=1.0
 # core browser automation
 playwright>=1.44
 # stealth plug-in (keep old pinned commit → оно стабильнее)
-playwright-stealth>=2.0.0,<2.1
+playwright-stealth==2.0.0
 # cursor movement automation
 python-ghost-cursor==0.1.1
 # only for local checks (optional): leave or drop


### PR DESCRIPTION
## Summary
- pin `playwright-stealth` to version 2.0.0 so `pip install` succeeds

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile Samokat-TP.py samokat_config.py`


------
https://chatgpt.com/codex/tasks/task_e_6882aa653f28832186bdb5ac6b1b897b