### PR TITLE
Add selectors config with init script

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 python -m venv venv && source venv/bin/activate
 pip install -r requirements.txt
 playwright install chromium  # once, to download browser binaries
+python tools/init_selectors.py  # optional: create selectors template
 ```
 
 Run script

--- a/selectors/default.yml
+++ b/selectors/default.yml
@@ -1,0 +1,9 @@
+# Селекторы формы по-умолчанию.
+# При необходимости создавайте дополнительные YAML-файлы
+# (например, `foodexpress.yml`) с той же схемой ключей.
+form:
+  name:      'input[name="name"]'          # поле «Имя»
+  phone:     'input[name="phone"]'         # поле «Телефон»
+  checkbox:  'input[type="checkbox"]'      # чекбокс согласия
+  submit:    'button[type="submit"]'       # кнопка «Отправить»
+  thank_you: '.modal-thanks'               # поп-ап «Спасибо»

--- a/tools/init_selectors.py
+++ b/tools/init_selectors.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Initialize default CSS selectors config."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+TEMPLATE = """# Селекторы формы по-умолчанию.
+# При необходимости создавайте дополнительные YAML-файлы
+# (например, `foodexpress.yml`) с той же схемой ключей.
+form:
+  name:      'input[name="name"]'          # поле «Имя»
+  phone:     'input[name="phone"]'         # поле «Телефон»
+  checkbox:  'input[type="checkbox"]'      # чекбокс согласия
+  submit:    'button[type="submit"]'       # кнопка «Отправить»
+  thank_you: '.modal-thanks'               # поп-ап «Спасибо»
+"""
+
+
+def main() -> None:
+    os.makedirs("selectors", exist_ok=True)
+    target = Path("selectors/default.yml")
+    if target.exists():
+        print("[init_selectors] selectors/default.yml already exists — skipped")
+        return
+    target.write_text(TEMPLATE, encoding="utf-8")
+    print("[init_selectors] selectors/default.yml created")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `selectors` directory with template `default.yml`
- add idempotent `tools/init_selectors.py`
- mention optional init script in installation docs

## Testing
- `python tools/init_selectors.py`
- `python - <<'PY'
import yaml, pathlib, sys, subprocess, os
subprocess.run([sys.executable, "tools/init_selectors.py"], check=True)
content = pathlib.Path("selectors/default.yml").read_text(encoding="utf-8")
data = yaml.safe_load(content)
assert {"name","phone","checkbox","submit","thank_you"} <= set(data["form"]), "Missing keys"
print("[test] OK")
PY
`

------
https://chatgpt.com/codex/tasks/task_e_68840507c9888321a38a7194bfd153e3