### PR TITLE
docs+refactor: unify selectors_profile logic and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,14 @@ cat <<EOF | python Samokat-TP.py
 {
   "user_phone": "79991234567",
   "user_name":  "Вася",
-  "headless":   true
+  "headless":   true,
+  "selectors_profile": "default"
 }
 EOF
 ```
+
+Поле *selectors_profile* задаёт файл `selectors/<name>.yml`.
+Если не указано — используется `default`.
 
 С прокси
 
@@ -36,6 +40,18 @@ cat params.json | python Samokat-TP.py --proxy=http://1.2.3.4:8080
 
 params.json – тот же JSON, который n8n отправляет в stdin (хз че эт). При отсутствии поля
 `headless` используется значение по умолчанию из `config_defaults.json`.
+
+Смена профиля селекторов
+
+```bash
+cat <<EOF | python Samokat-TP.py
+{
+  "user_phone": "79991234567",
+  "user_name":  "Тест",
+  "selectors_profile": "foodexpress"
+}
+EOF
+```
 
 ### Dependencies
 

--- a/Samokat-TP.py
+++ b/Samokat-TP.py
@@ -27,7 +27,7 @@ except ImportError:  # более старые версии
 # ------------------------------------------------------------------------------
 
 from samokat_config import CFG, load_cfg
-from utils import RunContext, log, make_log_file, version_check
+from utils import RunContext, log, make_log_file, version_check, load_selectors
 
 
 _REQUIRED = {
@@ -51,8 +51,6 @@ def _to_bool(val: str | bool) -> bool:
 
 
 try:
-    from pathlib import Path
-
     params = json.load(sys.stdin)
     json_headless_raw = params.get("headless")
     if json_headless_raw is not None:
@@ -1034,16 +1032,13 @@ if (window.WebGL2RenderingContext) {{
 async def main(ctx: RunContext):
     """Entry point for execution: load selectors then run browser."""
     global selectors
-    import yaml
-    import pathlib
-
     profile = params.get("selectors_profile", "default")
-    path = pathlib.Path("selectors") / f"{profile}.yml"
     try:
-        selectors = yaml.safe_load(path.read_text(encoding="utf-8"))
+        selectors = load_selectors(profile)
     except FileNotFoundError:
         raise RuntimeError(f"selectors profile '{profile}' not found")
 
+    path = Path("selectors") / f"{profile}.yml"
     log(f"[INFO] selectors profile: {profile} file: {path.resolve()}", ctx)
 
     await asyncio.wait_for(run_browser(ctx), timeout=CFG["RUN_TIMEOUT"])

--- a/tests/test_selectors.py
+++ b/tests/test_selectors.py
@@ -5,6 +5,9 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 import pytest
 
+import importlib.util
+import io
+import requests
 from utils import load_selectors
 
 
@@ -17,3 +20,27 @@ def test_load_selectors_default_equals_explicit(tmp_path, monkeypatch):
 def test_load_selectors_missing(tmp_path):
     with pytest.raises(FileNotFoundError):
         load_selectors("nonexistent_profile")
+
+
+def test_profile_default_consistency(monkeypatch):
+    path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "Samokat-TP.py")
+    spec = importlib.util.spec_from_file_location("stp", path)
+    stp = importlib.util.module_from_spec(spec)
+    assert spec.loader
+
+    class Resp:
+        status_code = 200
+
+    monkeypatch.setattr(requests, "post", lambda *a, **k: Resp())
+    monkeypatch.setattr(sys, "stdin", io.StringIO("{}"))
+
+    spec.loader.exec_module(stp)
+
+    async def dummy_run_browser(ctx):
+        return None
+
+    monkeypatch.setattr(stp, "run_browser", dummy_run_browser)
+    import asyncio
+
+    asyncio.run(stp.main(stp.ctx))
+    assert stp.selectors == load_selectors("default")


### PR DESCRIPTION
## Summary
- use `load_selectors()` inside script instead of manual YAML
- document `selectors_profile` usage and add profile switch example
- add unit test verifying default profile logic

## Testing
- `pytest -q`
- `black --check .`


------
https://chatgpt.com/codex/tasks/task_e_6884139ed2b483218f75fb06188c2bbc