### PR TITLE
Implement logging module and result footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,6 @@ Example `.env`:
 UA="Mozilla/5.0 ..."
 HEADLESS=false
 ```
+
+В конце каждого лога есть строка RESULT: SUCCESS или RESULT: ERROR.
+Путь к лог-файлу и скриншоту возвращается в JSON-ответе.

--- a/logger_setup.py
+++ b/logger_setup.py
@@ -1,0 +1,17 @@
+import logging
+import sys
+
+__all__ = ["get_logger"]
+
+_FMT = "[%(asctime)s] %(levelname)s %(name)s – %(message)s"
+logging.basicConfig(
+    level=logging.INFO,
+    format=_FMT,
+    datefmt="%H:%M:%S",
+    handlers=[logging.StreamHandler(sys.stderr)],
+    force=True,
+)
+
+
+def get_logger(name: str = "samokat") -> logging.Logger:
+    return logging.getLogger(name)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,42 @@
+import io
+import sys
+import json
+import importlib.util
+import asyncio
+
+
+def _run_script(monkeypatch, tmp_path, ok=True):
+    data = {"user_phone": "79990001234"}
+    if not ok:
+        data["headless"] = "not_bool"
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(data)))
+    monkeypatch.setattr(
+        "requests.post", lambda *a, **k: type("R", (), {"status_code": 200})()
+    )
+    spec = importlib.util.spec_from_file_location("stp", "Samokat-TP.py")
+    stp = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(stp)
+    except SystemExit:
+        return stp.ctx.log_file
+
+    async def dummy_run_browser(ctx):
+        return None
+
+    if hasattr(stp, "run_browser"):
+        monkeypatch.setattr(stp, "run_browser", dummy_run_browser)
+    try:
+        asyncio.run(stp.main(stp.ctx))
+    except SystemExit:
+        pass
+    return stp.ctx.log_file
+
+
+def test_result_success(monkeypatch, tmp_path):
+    lf = _run_script(monkeypatch, tmp_path, ok=True)
+    assert "RESULT: SUCCESS" in open(lf, encoding="utf-8").read()
+
+
+def test_result_error(monkeypatch, tmp_path):
+    lf = _run_script(monkeypatch, tmp_path, ok=False)
+    assert "RESULT: ERROR" in open(lf, encoding="utf-8").read()

--- a/utils.py
+++ b/utils.py
@@ -1,4 +1,4 @@
-"""Utilities: RunContext container and simple logging helpers."""
+"""Utilities: runtime context container and helper functions."""
 
 from __future__ import annotations
 
@@ -7,6 +7,8 @@ from dataclasses import dataclass
 from datetime import datetime
 import os
 import sys
+
+from logger_setup import get_logger
 
 __all__ = [
     "RunContext",
@@ -50,14 +52,8 @@ def make_log_file(logs_dir: str, phone: str) -> str:
         idx += 1
 
 
-def log(msg: str, ctx: RunContext | None = None) -> None:
-    """Write *msg* to ``ctx.log_file`` or stderr if context is missing."""
-    ts_txt = f"{datetime.now()}  {msg}"
-    if ctx and ctx.log_file:
-        with open(ctx.log_file, "a", encoding="utf-8") as f:
-            f.write(ts_txt + "\n")
-    else:
-        print(ts_txt, file=sys.stderr)
+# use ``logging`` module for all output
+log = get_logger("samokat").info
 
 
 def version_check(required: dict[str, tuple[str, str]]) -> None:


### PR DESCRIPTION
## Summary
- switch to `logging` via `logger_setup.py`
- replace custom log calls with standard logging
- record `RESULT: SUCCESS|ERROR` in logs
- return absolute paths for log and screenshot
- handle headless errors gracefully
- add tests for final RESULT line

## Testing
- `ruff check --fix Samokat-TP.py tests/test_logging.py samokat_config.py utils.py logger_setup.py`
- `black Samokat-TP.py tests/test_logging.py samokat_config.py utils.py logger_setup.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68849240f8f08321acdd9fd3d10f53c5