### PR TITLE
Fix logger arg and cursor tracking

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -34,6 +34,7 @@ class RunContext:
     browser_closed_manually: bool = False
     first_abort_logged: bool = False
     errors: list[str] = field(default_factory=list)
+    mouse_pos: tuple[float, float] = (0.0, 0.0)
 
     def clone(self) -> "RunContext":
         """Return a deep copy of this context."""


### PR DESCRIPTION
## Summary
- remove stray context argument from a logger call
- ensure mouse position is updated for each cursor movement

## Testing
- `black --check Samokat-TP.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688b4fb3666083219ec45c4fe54ef880