### PR TITLE
Use global CFG in scroll_to_form_like_reading

### DIFF
--- a/Samokat-TP.py
+++ b/Samokat-TP.py
@@ -775,8 +775,9 @@ async def scroll_to_form_like_reading(page, ctx: RunContext, timeout: float = 15
     import asyncio
     import time
 
-    CFG = ctx.CFG
     logger = ctx.logger
+    from samokat_config import CFG
+
     _rnd = ctx._rnd
 
     sel = CFG["SELECTORS"]["FORM_WRAPPER"]


### PR DESCRIPTION
## Summary
- import CFG from samokat_config instead of ctx

## Testing
- `pre-commit run --files Samokat-TP.py` *(fails: Error: Failed to download Chromium 124.0.6367.29 (playwright build v1112), caused by Error: Download failure, code=1)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688fc29f971c83219f2bbb5af53077f7