### PR TITLE
Limit webhook payload to minimal contract

### DIFF
--- a/Samokat-TP.py
+++ b/Samokat-TP.py
@@ -182,22 +182,18 @@ def send_result(
     proxy_used: bool,
 ) -> None:
     """Send final result via webhook and print JSON."""
-    result: dict[str, str | bool | None] = {"phone": phone, "proxy_used": proxy_used}
+    result: dict[str, str] = {"phone": phone}
 
     if ctx.errors:
         result["error"] = ", ".join(ctx.errors)
         if ctx.screenshot_path:
-            result["screenshot"] = os.path.abspath(ctx.screenshot_path)
+            result["screenshot"] = ctx.screenshot_path
+    elif ctx.postback:
+        result["POSTBACK"] = ctx.postback
     else:
-        if ctx.postback:
-            result["POSTBACK"] = ctx.postback
-        else:
-            result["error"] = "POSTBACK missing"
-            if ctx.screenshot_path:
-                result["screenshot"] = os.path.abspath(ctx.screenshot_path)
-
-    if ctx.log_file:
-        result["log"] = os.path.abspath(ctx.log_file)
+        result["error"] = "POSTBACK missing"
+        if ctx.screenshot_path:
+            result["screenshot"] = ctx.screenshot_path
 
     if headless_error and "error" not in result:
         result["error"] = "bad headless value"


### PR DESCRIPTION
## Summary
- send only required fields in webhook result
- include screenshot path solely when available

## Testing
- `ruff check Samokat-TP.py`
- `black --check Samokat-TP.py` *(fails: would reformat Samokat-TP.py)*
- `pre-commit run --files Samokat-TP_temp.py` *(fails: Failed to download Chromium)*

------
https://chatgpt.com/codex/tasks/task_e_6899fa605e288321a9bda50c444968f3